### PR TITLE
[ENHANCEMENT] Titlebar handling for different operating systems.

### DIFF
--- a/src/VRCFaceTracking.Avalonia/Views/MainView.axaml
+++ b/src/VRCFaceTracking.Avalonia/Views/MainView.axaml
@@ -22,6 +22,13 @@
                   Spacing="5"
                   HorizontalAlignment="Stretch"
                   VerticalAlignment="Top">
+        <Image Source="/Assets/VRCFT-logo-24.png"
+                 VerticalAlignment="Center"
+                 Margin="1,9,1,1" MinWidth="24"
+                 MaxWidth="24" MinHeight="24"
+                 MaxHeight="24"
+                 x:Name="ApplicationSidePanelLogo"
+                 IsVisible="False"/>
         <Button HorizontalAlignment="Left"
                 Width="32"
                 Height="32"
@@ -57,7 +64,7 @@
     </SplitView.Pane>
 
     <SplitView.Content>
-      <Border CornerRadius="16 0 0 0" Padding="5" Background="{DynamicResource SystemChromeMediumColor}">
+      <Border x:Name ="ViewContainer" CornerRadius="16 0 0 0" Padding="5" Background="{DynamicResource SystemChromeMediumColor}">
         <TransitioningContentControl Content="{Binding CurrentPage}" />
       </Border>
     </SplitView.Content>

--- a/src/VRCFaceTracking.Avalonia/Views/MainView.axaml.cs
+++ b/src/VRCFaceTracking.Avalonia/Views/MainView.axaml.cs
@@ -1,4 +1,7 @@
-﻿using Avalonia.Controls;
+﻿using Avalonia;
+using Avalonia.Controls;
+using System;
+
 
 namespace VRCFaceTracking.Avalonia.Views;
 
@@ -7,5 +10,22 @@ public partial class MainView : UserControl
     public MainView()
     {
         InitializeComponent();
+        SetupViewContainer();
+    }
+
+    private void SetupViewContainer()
+    {
+        if (OperatingSystem.IsIOS() || OperatingSystem.IsAndroid()) // mobile
+        {
+            ApplicationSidePanelLogo.IsVisible = true;
+            ViewContainer.CornerRadius = new CornerRadius(0, 0, 0, 0);
+        }
+        else
+        {
+            ApplicationSidePanelLogo.IsVisible = false;
+
+            // We will just default to the existing xaml to make it more straight-forward to adjust later.
+            //ViewContainer.CornerRadius = new CornerRadius(16, 0, 0, 0);
+        }
     }
 }

--- a/src/VRCFaceTracking.Avalonia/Views/MainWindow.axaml
+++ b/src/VRCFaceTracking.Avalonia/Views/MainWindow.axaml
@@ -32,11 +32,28 @@
       <RowDefinition Height="*" />
     </Grid.RowDefinitions>
 
-    <Border Grid.Row="0" Height="40" Classes="TitleBar" Name="ApplicationTitleBar" IsHitTestVisible="False">
+    <Border Grid.Row="0"
+            Height="40"
+            Classes="TitleBar"
+            x:Name="ApplicationTitleBar"
+            IsHitTestVisible="False"
+            IsVisible="False">
       <Grid>
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Margin="10,0,0,0" IsHitTestVisible="False">
-          <Image Source="/Assets/VRCFT-logo-24.png" VerticalAlignment="Center" Margin="1,1,1,1" MinWidth="24" MaxWidth="24" MinHeight="24" MaxHeight="24"/>
-          <TextBlock FontSize="12" Text="VRCFaceTracking" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="10,0,0,0" IsHitTestVisible="False"/>
+        <StackPanel Orientation="Horizontal"
+                    HorizontalAlignment="Left"
+                    Margin="10,0,0,0"
+                    IsHitTestVisible="False"
+                    x:Name="TitleBarContent">
+          <Image Source="/Assets/VRCFT-logo-24.png"
+                 VerticalAlignment="Center"
+                 MinWidth="24" MaxWidth="24"
+                 MinHeight="24" MaxHeight="24"/>
+          <TextBlock FontSize="12"
+                     Text="VRCFaceTracking"
+                     VerticalAlignment="Center"
+                     HorizontalAlignment="Left"
+                     Margin="10,0,0,0"
+                     IsHitTestVisible="False"/>
         </StackPanel>
       </Grid>
     </Border>

--- a/src/VRCFaceTracking.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/VRCFaceTracking.Avalonia/Views/MainWindow.axaml.cs
@@ -1,5 +1,9 @@
+using Avalonia;
+using Avalonia.Layout;
 using Avalonia.Controls;
+using System.Runtime.InteropServices;
 using VRCFaceTracking.Avalonia.ViewModels;
+using System;
 
 namespace VRCFaceTracking.Avalonia.Views;
 
@@ -12,6 +16,36 @@ public partial class MainWindow : Window
     {
         DataContext = vm;
         InitializeComponent();
+        AdjustTitleBarForPlatform();
+    }
+
+    private void AdjustTitleBarForPlatform()
+    {
+        if (OperatingSystem.IsIOS() || OperatingSystem.IsAndroid()) // mobile
+        {
+            // elements are already disabled.
+        }
+        else if (OperatingSystem.IsMacOS())
+        {
+            ApplicationTitleBar.IsVisible = true;
+            TitleBarContent.HorizontalAlignment = HorizontalAlignment.Center;
+        }
+        else if (OperatingSystem.IsWindows())
+        {
+            ApplicationTitleBar.IsVisible = true;
+            TitleBarContent.HorizontalAlignment = HorizontalAlignment.Left;
+        }
+        else if (OperatingSystem.IsLinux())
+        {
+            // Linux has so many edge cases, we will just let the OS handle titlebars.
+            SystemDecorations = SystemDecorations.Full;
+            ExtendClientAreaToDecorationsHint = false;
+        }
+        else // unknown platform, revert to use platform's decorations
+        {
+            SystemDecorations = SystemDecorations.Full;
+            ExtendClientAreaToDecorationsHint = false;
+        }
     }
 
     public MainWindow() : this(new MainViewModel()) { }


### PR DESCRIPTION
Simple adjustment to the titlebar based on the OS.

Examples of element positions (All pics are on Windows but they are oriented based on detected OS)

* Mobile:
![image](https://github.com/user-attachments/assets/762d4948-f8d1-4d14-a495-231cc394a866)

* MacOS:
![image](https://github.com/user-attachments/assets/e8d46e6f-905d-4de3-98e1-38e56847abd6)

* Windows
![image](https://github.com/user-attachments/assets/767a1a32-dae1-441b-ba96-879284b235b6)

* Linux / Undefined (Dependent on window manager)
![image](https://github.com/user-attachments/assets/76d7419b-788e-4942-b7ee-2368ee73fad1)
