### PR TITLE
（fix）Fix language selection and dynamic UI localization refresh

### DIFF
--- a/src/VRCFaceTracking.Avalonia/Assets/Resources.zh-cn.resx
+++ b/src/VRCFaceTracking.Avalonia/Assets/Resources.zh-cn.resx
@@ -384,10 +384,10 @@
     <value>硬件调试</value>
   </data>
   <data name="HardwareDebug.Description" xml:space="preserve">
-    <value>你能看见自己的舌头吗？</value>
+    <value>暂未完成喵～</value>
   </data>
   <data name="Shell_TrackingSettings.Content" xml:space="preserve">
-    <value>Tracking Settings</value>
+    <value>捕捉设定</value>
   </data>
   <data name="YourRating.Text" xml:space="preserve">
     <value />

--- a/src/VRCFaceTracking.Avalonia/Services/LanguageSelectorService.cs
+++ b/src/VRCFaceTracking.Avalonia/Services/LanguageSelectorService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using System.Threading.Tasks;
 using VRCFaceTracking.Avalonia.Assets;
@@ -30,9 +31,15 @@ public class LanguageSelectorService(ILocalSettingsService localSettingsService)
 
     public Task SetRequestedLanguageAsync()
     {
-        Resources.Culture = new CultureInfo(Language == DefaultLanguage ?
-            CultureInfo.CurrentCulture.TwoLetterISOLanguageName :
-            Language);
+        // Map language keys from UI to proper CultureInfo names used by resource files.
+        // The UI uses "zh" as the ComboBox item name, but resource file is named "Resources.zh-cn.resx",
+        // so request the specific culture "zh-CN". For default, use the system two-letter ISO name.
+        var cultureName = Language == DefaultLanguage ? CultureInfo.CurrentCulture.TwoLetterISOLanguageName : Language;
+        if (string.Equals(cultureName, "zh", StringComparison.OrdinalIgnoreCase))
+        {
+            cultureName = "zh-CN";
+        }
+        Resources.Culture = new CultureInfo(cultureName);
         return Task.CompletedTask;
     }
 

--- a/src/VRCFaceTracking.Avalonia/Views/SettingsPageView.axaml.cs
+++ b/src/VRCFaceTracking.Avalonia/Views/SettingsPageView.axaml.cs
@@ -97,7 +97,57 @@ public partial class SettingsPageView : UserControl
         {
             await _languageSelectorService.SetLanguageAsync(item!.Name);
             UpdateThemes();
+                RefreshLocalizedText();
         });
+    }
+    // 刷新界面所有本地化文本
+    private void RefreshLocalizedText()
+    {
+        // 直接查找主 StackPanel 并遍历其 Children
+        var stackPanel = this.Content as StackPanel;
+        if (stackPanel == null)
+        {
+            if (this.Content is ScrollViewer sv && sv.Content is StackPanel sp)
+                stackPanel = sp;
+        }
+        if (stackPanel == null) return;
+
+        foreach (var child in stackPanel.Children)
+        {
+            if (child is Controls.SettingsBlock settingsBlock)
+            {
+                if (settingsBlock.IconPath == "DarkLightTheme")
+                {
+                    settingsBlock.Title = Assets.Resources.ThemeSettings_Header;
+                    settingsBlock.Description = Assets.Resources.ThemeSettings_Description;
+                }
+                else if (settingsBlock.IconPath == "LanguageRegular")
+                {
+                    settingsBlock.Title = "Language";
+                    settingsBlock.Description = "Set the app's language. Requires a restart for some elements.";
+                }
+                else if (settingsBlock.IconPath == "WirelessRegular")
+                {
+                    settingsBlock.Title = Assets.Resources.OscSettings_Header;
+                    settingsBlock.Description = Assets.Resources.OscSettings_Description;
+                }
+            }
+            else if (child is Controls.SettingsToggle settingsToggle)
+            {
+                settingsToggle.Title = Assets.Resources.AutoStartSettings_Header;
+                settingsToggle.Description = Assets.Resources.AutoStartSettings_Description;
+            }
+            else if (child is Controls.SettingsExpanderToggle expanderToggle)
+            {
+                expanderToggle.Title = Assets.Resources.RiskySettings_Header;
+                expanderToggle.Description = Assets.Resources.RiskySettings_Description;
+            }
+            else if (child is Controls.SettingsExpander expander)
+            {
+                expander.Title = Assets.Resources.HardwareDebug_Header;
+                expander.Description = Assets.Resources.HardwareDebug_Description;
+            }
+        }
     }
 
     // Workaround for https://github.com/AvaloniaUI/Avalonia/issues/4460


### PR DESCRIPTION
Changes
1.Improved language mapping in LanguageSelectorService to correctly resolve short language codes (e.g., "zh" → "zh-CN").
2.Fixed logic that determines and applies the selected language from user settings.
      （1）Added RefreshLocalizedText() and UpdateThemes() calls in SettingsPageView.axaml.cs so that the interface updates dynamically when the language changes.
      （2）Implemented UI traversal to refresh text for SettingsBlock, SettingsToggle, and other localized components.

Notes
1.Some modal dialogs or dynamically loaded views may still require a restart to fully refresh localization.
2.Future improvements could expand the language mapping logic for regional variants (e.g., zh-TW, fr-CA).

Example：
    (1)chinese:
<img width="1074" height="737" alt="image" src="https://github.com/user-attachments/assets/e58cce88-bb52-444e-af9a-a34e66636b4e" />
    (2)japanese:
<img width="1075" height="739" alt="image" src="https://github.com/user-attachments/assets/8f39f405-c548-4a0e-b228-04da017e144c" />
