### PR TITLE
build: add nixConfig useSandbox = false

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,11 @@
   };
   inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
 
+  # Dependency downloads are currently broken, if anyone can get it working, feel free to make a PR
+  nixConfig = {
+    sandbox = false;
+  };
+
   outputs = { self, nixpkgs, vrcft, desktopNotifications, hyperText, ... }: let
     systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin"];
     forAllSystems = nixpkgs.lib.genAttrs systems;


### PR DESCRIPTION
## Add nixConfig

I found out about the existence of this recently in another project (https://github.com/an-anime-team/an-anime-game-launcher/blob/main/flake.nix#L12-L24)

## Before

```sh
$ nix build
error: Cannot build '/nix/store/qnhg1kzxl21arm1v42jqzdbi1d4qjvc2-vrchatfacetracking-1.1.0.0.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/0mi96pkvxawi2r4s5fsxr38sjjc1aiyb-vrchatfacetracking-1.1.0.0
       Last 18 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/qq22mvajl4xm70hdwrv0lc6mr7i0b2b5-zjcv8hzi8xiqy8p2zylycmsr5l49kg11-source
       > source root is zjcv8hzi8xiqy8p2zylycmsr5l49kg11-source
       > Running phase: patchPhase
       > Running phase: configureNuget
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > Executing dotnetConfigureHook
       >   Determining projects to restore...
       >   Skipping project "/build/zjcv8hzi8xiqy8p2zylycmsr5l49kg11-source/src/HyperText.Avalonia/HyperText.Avalonia/HyperText.Avalonia.csproj" because it was not found.
       >   Skipping project "/build/zjcv8hzi8xiqy8p2zylycmsr5l49kg11-source/src/VRCFaceTracking/VRCFaceTracking.Core/VRCFaceTracking.Core.csproj" because it was not found.
       >   Skipping project "/build/zjcv8hzi8xiqy8p2zylycmsr5l49kg11-source/src/HyperText.Avalonia/HyperText.Avalonia/HyperText.Avalonia.csproj" because it was not found.
       >   Skipping project "/build/zjcv8hzi8xiqy8p2zylycmsr5l49kg11-source/src/VRCFaceTracking/VRCFaceTracking.Core/VRCFaceTracking.Core.csproj" because it was not found.
       > /build/zjcv8hzi8xiqy8p2zylycmsr5l49kg11-source/src/VRCFaceTracking.Avalonia.Desktop/VRCFaceTracking.Avalonia.Desktop.csproj : error NU1301: Unable to load the service index for source https://api.nuget.org/v3/index.json.
       > /build/zjcv8hzi8xiqy8p2zylycmsr5l49kg11-source/src/VRCFaceTracking.Avalonia/VRCFaceTracking.Avalonia.csproj : error NU1301: Unable to load the service index for source https://api.nuget.org/v3/index.json. [/build/zjcv8hzi8xiqy8p2zylycmsr5l49kg11-source/src/VRCFaceTracking.Avalonia.Desktop/VRCFaceTracking.Avalonia.Desktop.csproj]
       > /build/zjcv8hzi8xiqy8p2zylycmsr5l49kg11-source/src/VRCFaceTracking.Avalonia.Desktop/VRCFaceTracking.Avalonia.Desktop.csproj : error NU1301: Unable to load the service index for source https://api.nuget.org/v3/index.json.
       >   Failed to restore /build/zjcv8hzi8xiqy8p2zylycmsr5l49kg11-source/src/VRCFaceTracking.Avalonia/VRCFaceTracking.Avalonia.csproj (in 5.78 sec).
       >   Failed to restore /build/zjcv8hzi8xiqy8p2zylycmsr5l49kg11-source/src/VRCFaceTracking.Avalonia.Desktop/VRCFaceTracking.Avalonia.Desktop.csproj (in 5.78 sec).
       For full logs, run:
         nix log /nix/store/qnhg1kzxl21arm1v42jqzdbi1d4qjvc2-vrchatfacetracking-1.1.0.0.drv
```

## After

```sh
$ nix build
do you want to allow configuration setting 'sandbox' to be set to 'false' (y/N)? y 
do you want to permanently mark this value as trusted (y/N)? y
```
